### PR TITLE
Edit the sendgrid free details

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Table of Contents
   * [tinyletter.com](https://tinyletter.com/) — 5,000 subscribers/month are free
   * [mailchimp.com](http://mailchimp.com/) — 2,000 subscribers and 12,000 emails/month are free
   * [sendloop.com](https://sendloop.com/) — 2,000 subscribers and 10,000 emails/month are free
-  * [sendgrid.com](https://sendgrid.com/) — 400 emails/day for free and 25,000 free transactional emails/month for emails sent from a Google compute instance or Microsoft Azure App Service
+  * [sendgrid.com](https://sendgrid.com/) — 12,000 emails/month and 2,000 contacts for free
   * [phplist.com](https://phplist.com/) — Hosted version allow 300 emails/month for free
   * [mailjet.com](https://www.mailjet.com/) — 6,000 emails/month for free
   * [sendinblue.com](https://www.sendinblue.com/) — 9,000 emails/month for free


### PR DESCRIPTION
Sendgrid's free details have changed to include 12,000 emails per month
and allow you to store 2,000 contacts for free.

[Sendgrid's pricing](https://sendgrid.com/pricing/)
